### PR TITLE
Update Github Actions from Node 16 to 20

### DIFF
--- a/.github/workflows/webpack-build.yml
+++ b/.github/workflows/webpack-build.yml
@@ -2,7 +2,7 @@ name: Build with webpack
 
 on:
   pull_request:
-    branches: [ "gh-pages" ]
+    branches: ['gh-pages']
   workflow_call:
 
 jobs:
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version-file: package.json
 
       - name: Build
         run: |
@@ -24,6 +24,6 @@ jobs:
           npm run build
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: build/

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0"
+  },
+  "engines": {
+    "node": ">=18.19.1"
   }
 }


### PR DESCRIPTION
Summary
---

This pull request updated both the actions and node version.
* Actions: to the latest version
* Node: from 18 to 20

Context
---

I noticed the following warning in [the latest deploy workflow](https://github.com/myjian/mai-tools/actions/runs/8345971251).

**build / build**
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

**deploy**
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/deploy-pages@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

