### PR TITLE
Rating calc: CSS fix on +Rating Column

### DIFF
--- a/src/rating-calculator/components/ChartRecordDataRow.tsx
+++ b/src/rating-calculator/components/ChartRecordDataRow.tsx
@@ -67,7 +67,7 @@ export const ChartRecordDataRow = React.memo((props: Props) => {
           return record.nextRanks
             ? Array.from(record.nextRanks.values()).map((r, idx) => (
                 <div key={idx}>{Math.floor(record.level*r.rank.factor*(r.rank.minAchv/100)).toFixed(0)}
-                  {' '}(+{r.minRt.toFixed(0)})</div>
+                  (+{r.minRt.toFixed(0)})</div>
               ))
             : '';
         case ColumnType.RATING:

--- a/src/rating-calculator/css/song-record-styles.css
+++ b/src/rating-calculator/css/song-record-styles.css
@@ -88,6 +88,7 @@ td.achievementCell {
 }
 
 td.nextRatingCell {
+  white-space: nowrap;
   text-align: left;
 }
 


### PR DESCRIPTION
Fix word wrap on mobile devices

To save space, also remove the white space added

<img width="410" alt="Screenshot 2024-03-25 at 7 44 39 PM" src="https://github.com/myjian/mai-tools/assets/162117433/a26ef33c-2da4-481f-89e9-d6941227904f">
<img width="406" alt="Screenshot 2024-03-25 at 7 44 27 PM" src="https://github.com/myjian/mai-tools/assets/162117433/72019e66-9f6b-4d95-8c7d-386fdede57e4">
<img width="404" alt="Screenshot 2024-03-25 at 7 44 20 PM" src="https://github.com/myjian/mai-tools/assets/162117433/8406eeb1-f68d-4f80-aa8e-426de3cd9ef2">
<img width="418" alt="Screenshot 2024-03-25 at 7 44 05 PM" src="https://github.com/myjian/mai-tools/assets/162117433/4e18dd2c-d327-490f-afa1-80071d5baddd">
<img width="416" alt="Screenshot 2024-03-25 at 7 43 58 PM" src="https://github.com/myjian/mai-tools/assets/162117433/358bac10-1987-4772-9f40-448bb6b73a57">
<img width="406" alt="Screenshot 2024-03-25 at 7 43 42 PM" src="https://github.com/myjian/mai-tools/assets/162117433/61f9ccc8-52bf-4b96-a2ff-8d27cffd23f6">
<img width="425" alt="Screenshot 2024-03-25 at 7 43 36 PM" src="https://github.com/myjian/mai-tools/assets/162117433/de29662f-e8c3-4ffb-adce-6d626574d8f2">
