### PR TITLE
fix(rating-calculator): simplify .rankDistributionTable color

### DIFF
--- a/src/rating-calculator/components/DifficultyDistribution.tsx
+++ b/src/rating-calculator/components/DifficultyDistribution.tsx
@@ -73,9 +73,8 @@ export const DifficultyDistribution = ({chartRecords, topChartsCount}: Props) =>
                 rowHead={getDifficultyName(d)}
                 columns={chartTypeNames}
                 rankDist={dist}
-                rowClassname={getDifficultyClassName(d)}
                 baseCellClassname={DIFF_RANK_CELL_BASE_CLASSNAME}
-                perColumnClassnames={[]}
+                perColumnClassnames={[getDifficultyClassName(d)]}
               />
             );
           })}

--- a/src/rating-calculator/css/rank-distributon-styles.css
+++ b/src/rating-calculator/css/rank-distributon-styles.css
@@ -24,8 +24,6 @@ td.diffRankCell {
 td.levelRankCell,
 td.diffRankCell {
   text-align: center;
-  color: initial;
-  text-shadow: initial;
 }
 
 .officialLevelCell {

--- a/src/rating-calculator/css/styles.css
+++ b/src/rating-calculator/css/styles.css
@@ -1,5 +1,6 @@
 html {
   background-color: #eee;
+  color: #000;
 }
 
 body {


### PR DESCRIPTION
Removing `color: initial` and narrowing the scope of the difficulty classes on `DifficultyDistribution`.

`color: initial` depends on the browser's color config, so it can make the text invisible.

### Before
The text color in browser config is #eee.
![Screenshot 2024-05-28 at 20-50-31 maimai DX Rating Analyzer](https://github.com/myjian/mai-tools/assets/14163516/49f0d622-db8f-47ad-ae19-4a9f34680a3b)

### After
![Screenshot 2024-05-28 at 20-54-28 maimai DX Rating Analyzer](https://github.com/myjian/mai-tools/assets/14163516/50be5eb1-57f4-4391-b27b-9d73516f4090)
