### PR TITLE
Rename game versions for でらっくす and でらっくす PLUS

### DIFF
--- a/src/common/game-version.ts
+++ b/src/common/game-version.ts
@@ -20,8 +20,8 @@ const VERSION_NAMES = [
   'MiLK', // 10
   'MiLK PLUS',
   'FiNALE', // 12
-  'maimaiでらっくす',
-  'maimaiでらっくす PLUS',
+  'でらっくす',
+  'でらっくす PLUS',
   'Splash', // 15
   'Splash PLUS',
   'UNiVERSE', // 17


### PR DESCRIPTION
Enhance readbility by removing "maimai" from these two versions to prevent the column width for ratings from expanding.